### PR TITLE
configure: Correctly check for $NO_CAMLIDL.

### DIFF
--- a/configure
+++ b/configure
@@ -289,7 +289,7 @@ fi >&2
 
 # - checking camlidl *
 echo-check for camlidl
-if [ -n "${NO_CAMLIDL:-}" ]; then
+if [ "X$NO_CAMLIDL" = "X1" ]; then
     HAS_CAMLIDL=
     CAMLIDL=
     echo-ok Disabled


### PR DESCRIPTION
This fixes a regression introduced with c65859270d0197769c784e52de79afeba0950b27.
