### PR TITLE
Add %z (timezone) handling in Date code.

### DIFF
--- a/libbase/time.ml
+++ b/libbase/time.ml
@@ -105,6 +105,14 @@ let local_wday time = (localtime time).Unix.tm_wday
 let local_yday time = (localtime time).Unix.tm_yday
 let local_isdst time = (localtime time).Unix.tm_isdst
 
+let local_timezone_offset () =
+  let t = Unix.time() in
+  let gmt = Unix.gmtime(t) in
+  let local = Unix.localtime(t) in
+  let (gmt_s, _) = Unix.mktime(gmt) in
+  let (local_s, _) = Unix.mktime(local) in
+  int_of_float((gmt_s -. local_s) /. 60.0);;
+
 let mktime ~year ~month ~day ~h ~min ~sec ~ms =
   let res =
     of_unix_time (

--- a/libbase/time.mli
+++ b/libbase/time.mli
@@ -52,6 +52,7 @@ val local_year : t -> int
 val local_wday : t -> int
 val local_yday : t -> int
 val local_isdst : t -> bool
+val local_timezone_offset : unit -> int
 
 val mktime : year:int -> month:int -> day:int -> h:int -> min:int -> sec:int -> ms:int -> t
 

--- a/opabsl/jsbsl/bslTime.js
+++ b/opabsl/jsbsl/bslTime.js
@@ -159,6 +159,13 @@ function now()
     return t.getHours();
 }
 
+##register local_timezone_offset : time_t -> int
+    ##args(f)
+{
+    var t = new Date(); t.setTime(f)
+    return t.getTimezoneOffset();
+}
+
 ##register local_mday : time_t -> int
     ##args(f)
 {

--- a/opabsl/mlbsl/bslTime.ml
+++ b/opabsl/mlbsl/bslTime.ml
@@ -83,6 +83,9 @@
    ##register local_hour : time_t -> int
    let local_hour t = Time.local_hour (wrap t)
 
+   ##register local_timezone_offset : time_t -> int
+   let local_timezone_offset _ = Time.local_timezone_offset()
+
    ##register local_mday : time_t -> int
    let local_mday t = Time.local_mday (wrap t)
 

--- a/stdlib/core/date/date_private.opa
+++ b/stdlib/core/date/date_private.opa
@@ -105,6 +105,9 @@ import stdlib.core.parser
   time_local_hour : Date.date -> int =
     date_in(%%BslTime.local_hour%% : time_t -> int)   // Hours 0..23
 
+  time_local_timezone_offset : Date.date -> int =
+    date_in(%%BslTime.local_timezone_offset%% : time_t -> int)
+
   time_local_mday : Date.date -> int =
     date_in(%%BslTime.local_mday%% : time_t -> int)   // Day of month 1..31
 
@@ -181,6 +184,7 @@ import stdlib.core.parser
       , ("x", true,  ((p, d) -> pad(Date.get_msec(d), p, {pad_with_zeros}, 3)))
       , ("y", false, ((_, d) -> pad(mod(Date.get_year(d), 100), {pad_with_zeros}, {pad_with_zeros}, 2)))
       , ("Y", true,  ((p, d) -> pad(Date.get_year(d), p, {pad_with_spaces}, 4)))
+      , ("z", true, ((_, _) -> Date.get_local_timezone()))
       ]
 
     padding_flag_parser = parser
@@ -328,6 +332,7 @@ import stdlib.core.parser
       , ("x", parse_num(v -> d -> {d with ms = v}))
       , ("y", parse_num(v -> d -> {d with year=if v < 70 then 2000 + v else 1900 + v}))
       , ("Y", parse_num(v -> d -> {d with year=v}))
+//      , ("z", *not supported for parsing*
       ]
 
     parse_directive_with((d, p)) =


### PR DESCRIPTION
This diff does not add total timezone handling (i.e. it doesn't allow you to parse the timezone from a string and/or mess around with timezone values). The main purpose of this diff is to have the ability to tell which timezone the server or client is running in, which is sometimes useful.
