### PR TITLE
Fix json serialization code

### DIFF
--- a/stdlib/core/rpc/core/opaserialize.opa
+++ b/stdlib/core/rpc/core/opaserialize.opa
@@ -733,6 +733,10 @@ OpaSerializeClosure = {{
          record_to_list(json,[])
 
       /* Particular named type ******************/
+      /* Bool */
+      | (_, {TyName_ident = "bool"; TyName_args = _}) ->
+        magic_some(json)
+
       /* Session */
       | (_, {TyName_ident = "Session.private.native"; TyName_args = _})
       | (_, {TyName_ident = "channel"; TyName_args = _})


### PR DESCRIPTION
Prior to this diff, boolean values are serialized as records. While that works, I don't see why we shouldn't use json boolean values directly,
especially since stdlib/core/rpc/core/json.opa knows about it already.

Here is how I tested this:
Debug.warning(Json.serialize(OpaSerialize.Json.serialize({x: true, y: 1})))

Before this diff:
{"y":1,"x":{"true":{}}}

With this diff:
{"y":1,"x":true}
