### PR TITLE
Update keyword recognition in S4 syntax for vim

### DIFF
--- a/utils/vim/syntax/opa.vim
+++ b/utils/vim/syntax/opa.vim
@@ -16,7 +16,7 @@ syn spell default
 syn keyword  opaType           int list char string option float void bool
 syn keyword  opaIf             if then else
 syn keyword  opaMatch          match with end
-syn keyword  opaKeywords       do type and rec as
+syn keyword  opaKeywords       do type and rec as or recursive function
 syn keyword  opaPackage        import import-plugin package
 syn keyword  opaDatabase       database db
 syn keyword  opaParser         parser


### PR DESCRIPTION
Add keywords 'function', 'or' and 'recursive' (former 'rec').
