### PR TITLE
[fix] build/myocamlbuild_prefix.ml: Correct the sed for FreeBSD 7.x.

### DIFF
--- a/build/myocamlbuild_prefix.ml
+++ b/build/myocamlbuild_prefix.ml
@@ -328,7 +328,7 @@ let _ = dispatch begin function
            (* FreeBSD 8.x and above have added -r that does exactly same as -E
               for increased compatibility with GNU sed. Since FreeBSD still
               supports 7.x that does not has -r, so use -E instead. The -r
-              does not exist in MacOS X sed either.*)
+              does not exist in MacOS X sed either. *)
            if is_fbsd && is_mac then
              Cmd(S[sed; A"-E"; A sedexpr; P(env "%.mllibp"); Sh">"; P(env "%.mllib")])
            else


### PR DESCRIPTION
[fix] build/myocamlbuild_prefix.ml: FreeBSD 8.x and above have added -r in its sed that does exactly same as -E for increased compatibility with GNU sed. Since FreeBSD still supports 7.x that its sed does not has -r, so use -E instead.
