### PR TITLE
[fix] lib/stdlib/extract-import-plugin.sh: Replace the sed(1) with /n to...

### DIFF
--- a/lib/stdlib/extract-import-plugin.sh
+++ b/lib/stdlib/extract-import-plugin.sh
@@ -4,4 +4,4 @@
 # source platform_helper (for sed)
 . ${OPA_SOURCE_DIR:-$(dirname $0)/../../}/tools/platform_helper.sh
 
-sed -n "s%^ *import-plugin  *\\(.*\\) *$%\\1%p" $1 | sed -e "s/{//" -e "s/}//" -e "s/, */\n/g"
+sed -n "s%^ *import-plugin  *\\(.*\\) *$%\\1%p" $1 | sed -e "s/{//" -e "s/}//" -e "s/, /,/g" | tr ',' '\n'


### PR DESCRIPTION
[fix] lib/stdlib/extract-import-plugin.sh: Replace the sed(1) with \n to tr(1).

The sed(1) in FreeBSD and possible MacOS X doesn't has '\n' support, so replace it to tr(1) to fix the build. I think it should works for Linux too. Here's build error on FreeBSD:

```
  Ocamlbuild knows of no rules that apply to a target named lib/plugins/opa-both-packages.stamp. This can happen if you ask Ocamlbuild to build a target with the wrong extension (e.g. .opt instead of .native) or if the source files live in directories that have not been specified as include directories.
Backtrace:
  - Failed to build the target opa-both-packages.stamp
      - Failed to build all of these:
          - Building lib/plugins/opa-both-packages.stamp
          - Building tools/build/opa-both-packages.stamp
          - Building compiler/opa-both-packages.stamp
          - Building lib/opa-both-packages.stamp
          - Building ocamllib/opa-both-packages.stamp
          - Building tools/opa-both-packages.stamp
          - Building opa-both-packages.stamp:
              - Building opa-node-packages.stamp:
                  - Building lib/plugins/cryptonunixnserver/cryptonunixnserver.oppf:
                      - Building lib/plugins/cryptonunixnserver/cryptonunixnserver.opa_plugin
Compilation unsuccessful after building 2886 targets (0 cached) in 00:05:10.
```

As you can see that there is no 'cryptonunixnserver' stuff. The '\n' is the result of add 'n' in the between of crypto, unix and server. To run the lib/stdlib/all_plugins.sh before patch and I get this:

```
# sh ./all_plugins.sh 
opabsl
badop
browser_canvas
crypto
cryptonunixnserver <-- Here
gcharts
hlnet
iconv
irc
mail
mongo
qos
server
servernunix <-- Here
socket
unix
unixnserver <-- Here
```

After applied the patch and I get this:

```
# sh ./all_plugins.sh
opabsl
badop
browser_canvas
crypto
gcharts
hlnet
iconv
irc
mail
mongo
qos
server
socket
unix
```
