### PR TITLE
[fix] tools/build/myocamlbuild_prefix.ml: Change from && to || between FreeBSD and MacOS X.

### DIFF
--- a/tools/build/myocamlbuild_prefix.ml
+++ b/tools/build/myocamlbuild_prefix.ml
@@ -342,7 +342,7 @@ let _ = dispatch begin function
               for increased compatibility with GNU sed. Since FreeBSD still
               supports 7.x that does not has -r, so use -E instead. The -r
               does not exist in MacOS X sed either. *)
-           if is_fbsd && is_mac then
+           if is_fbsd || is_mac then
              Cmd(S[sed; A"-E"; A sedexpr; P(env "%.mllibp"); Sh">"; P(env "%.mllib")])
            else
              Cmd(S[sed; A"-r"; A sedexpr; P(env "%.mllibp"); Sh">"; P(env "%.mllib")]));


### PR DESCRIPTION
[fix] tools/build/myocamlbuild_prefix.ml: Change from && to || between FreeBSD and MacOS X.

It was a silly mistake of mine that created a simple bug. It needs to be changed from and (&&) to or (||) in the between of is_fbsd and is_mac to correct a bug. I am surprised that nobody (even me!) has noticed my simple bug. :-)
