### PR TITLE
Fix int of string

### DIFF
--- a/lib/plugins/opabsl/nodejsbsl/bslNumber.nodejs
+++ b/lib/plugins/opabsl/nodejsbsl/bslNumber.nodejs
@@ -73,7 +73,12 @@ function int_of_string(str) {
  */
 function int_of_string_opt(str) {
     try {
-        js_some(int_of_string(str));
+        var res = int_of_string(str);
+        if (isNaN(res)) {
+            return js_none;
+        } else {
+            return js_some(res);
+        }
     } catch(e) {
         return js_none;
     }


### PR DESCRIPTION
There is a bug when trying to read an int and return an option. It has to do with NaN's returned by parseInt. This patch fixes that.
