### PR TITLE
[Fix] doc typo

### DIFF
--- a/lib/stdlib/core/web/resource/resource.opa
+++ b/lib/stdlib/core/web/resource/resource.opa
@@ -750,6 +750,6 @@ html(title:string, body:xhtml) = Resource.page(title:string, body: xhtml)
 /**
  * Combine two chunks of xhtml.
  *
- * [a <+> b] is the same thing as <>{a}{b}</>
+ * [a <+> b] is the same thing as [<>{a}{b}</>]
  */
 `<+>`(left_chunk:xhtml, right_chunk:xhtml) = <>{left_chunk}{right_chunk}</>


### PR DESCRIPTION
- \* [a <+> b] is the same thing as <>{a}{b}</>
- \* [a <+> b] is the same thing as [<>{a}{b}</>]
