### PR TITLE
support both "node" and "nodejs" as nodejs executables

### DIFF
--- a/configure
+++ b/configure
@@ -312,17 +312,22 @@ else
 fi
 
 # - checking for nodejs
+# On Debian, node is now called nodejs. The configure script prefers the latter
+# if it exists, as node might be some other program when both exist.
 echo-check for nodejs
-if which node &>/dev/null; then
-    echo-ok found
+NODE_EXEC=""
+if which nodejs &>/dev/null; then NODE_EXEC=nodejs; else
+	if which node &>/dev/null; then NODE_EXEC=node; fi; fi
+if [ "$NODE_EXEC" != "" ]; then
+	echo-ok found: $NODE_EXEC
 else
-    echo-err Not found
-    exit 1
+	echo-err Not found
+	exit 1
 fi
 
 # - checking for nodejs version
 echo-check for nodejs version
-NODE_VERSION=$(node --version)
+NODE_VERSION=$($NODE_EXEC --version)
 NODE_MIN_VERSION="v0.6"
 if [[ $NODE_VERSION > $NODE_MIN_VERSION ]]; then
     echo-ok $NODE_VERSION

--- a/tools/dependencies/launch_helper.sh
+++ b/tools/dependencies/launch_helper.sh
@@ -10,7 +10,10 @@
 #    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ###################################
 
-node=`which node 2>&1`
+# On Debian, node is now called nodejs. The configure script prefers the latter
+# if it exists, as node might be some other program when both exist.
+if which nodejs &>/dev/null; then node=$(which nodejs); else
+	if which node &>/dev/null; then node=$(which node); fi; fi
 if [ $? -ne 0 ] || [ ! -x "$node" ]; then
 
     NODE_VERSION=v0.8.7
@@ -78,4 +81,4 @@ if [ $? -ne 0 ] || [ ! -x "$node" ]; then
 fi;
 
 if [ $? -ne 0 ]; then exit $?; fi;
-node "$0" "$@"; exit $?;
+$node "$0" "$@"; exit $?;


### PR DESCRIPTION
Nowadays, Debian comes with 'nodejs' instead of 'node' as nodejs executable. When compiling an opa project, the .exe file will incorrectly assume that nodejs is some executable called 'node'.

The changes in the configure script enable compiling opa itself on systems where nodejs is called 'nodejs'.
The changes in launch_helper.sh enable projects to run out of the box from the .exe opa creates on systems where nodejs is called 'nodejs'.
