### PR TITLE
Fix get host

### DIFF
--- a/lib/stdlib/core/web/request/http_request.opa
+++ b/lib/stdlib/core/web/request/http_request.opa
@@ -128,7 +128,7 @@ HttpRequest = {{
        header_get = raw_values(request)}
 
     get_host(x: HttpRequest.request): option(string) =
-      get_headers(x).header_get("Host")
+      get_headers(x).header_get("host")
 
     is_secured(x: HttpRequest.request): bool =
       request    = get_low_level_request(x)


### PR DESCRIPTION
The function HttpRequest.get_host() was not working when I have tried to migrate from old opa (0.9.4 to the new version 1.1.0).

After investigation it was in fact HttpRequest.Generic.get_host. 
