### PR TITLE
[feature] add Session.set_connection_lost_handler

### DIFF
--- a/lib/plugins/server/session.js
+++ b/lib/plugins/server/session.js
@@ -114,10 +114,18 @@ var LowLevelPingLoop = {};
 
     var linked_with_server = true;
 
+    // for setting a custom handler when the connection
+    // between client and server is lost.
+    var connection_lost_handler = null;
+
     function break_ping_loop() {
         linked_with_server = false;
-        jlog("Error: the connexion with the server seems to be lost. Please reload");
-        throw("Error: the connexion with the server seems to be lost. Please reload");
+        if (connection_lost_handler == null) {
+          jlog("Error: the connection with the server seems to be lost. Please reload");
+          throw("Error: the connection with the server seems to be lost. Please reload");
+        } else {
+          connection_lost_handler();
+        }
     }
 
     // Domain used for AJAX request
@@ -469,8 +477,13 @@ var LowLevelPingLoop = {};
         /** Make somethings when an error occurs with the ping loop */
         function error_ping_response(xhr, str, exn){
             if (failure_delay == max_failure_delay){
-                jlog("Error: the connexion with the server seems to be lost");
+              if (connection_lost_handler == null) {
+                jlog("Error: the connection with the server seems to be lost.");
                 return;
+              } else {
+                connection_lost_handler();
+                return;
+              }
             } else {
                 //jlog("Warning: could not reach the server. Retrying in " + failure_delay);
             }
@@ -569,6 +582,10 @@ var LowLevelPingLoop = {};
 
     LowLevelSession.set_domain_url = function(d) {
 	domain_url = d;
+    }
+
+    LowLevelSession.set_connection_lost_handler = function(h) {
+      connection_lost_handler = h;
     }
 
     LowLevelSession.llmake = function(st, unserialize, fun_session,
@@ -752,6 +769,14 @@ var LowLevelPingLoop = {};
 function set_uu(x0, x1) {
     LowLevelSession.set_uu(x0, x1);
     return js_void;
+}
+
+/**
+ * @register {(-> void) -> void}
+ */
+function set_connection_lost_handler(f) {
+  LowLevelSession.set_connection_lost_handler(f);
+  return js_void;
 }
 
 /**

--- a/lib/stdlib/core/rpc/core/session.opa
+++ b/lib/stdlib/core/rpc/core/session.opa
@@ -190,6 +190,20 @@ Session = {{
     @client set_domain_url = %%Session.set_domain_url%%
 
     /**
+     * Set a custom handler function for the case when the
+     * connection between client and server appears to be
+     * lost. If this in not set, the default is to print
+     * "the connection with the server seems to be lost" to
+     * the client screen.
+     *
+     * Be sure to pass a `client` function here (e.g.
+     * `client function my_handler() { ... }`), as it will
+     * probably be called when the server is not available!
+     */
+    @client set_connection_lost_handler =
+      %%Session.set_connection_lost_handler%%
+
+    /**
      * {2 Creating sessions}
      */
 


### PR DESCRIPTION
Added a way to set a custom callback function to be called
when the client detects that it has been disconnected
from the server.

Prior to this patch, the behavior was always to print to
the jlog (browser page): "The connexion to the server seems
to have been lost." Now the programmer can customize this
behavior.

Here is a fully-functional and tested usage case:

```
  import stdlib.core.rpc.core;
  import stdlib.web.client;

  client function my_connection_lost_handler() {
    Client.alert("connection lost, press OK to reload");
    Client.reload();
  }

  function setup_handler() {
    Session.set_connection_lost_handler(my_connection_lost_handler);
  }

  function page() {
    <div onready={function(_) { setup_handler() }}>
     this is the <strong>custom connection handler
     test</strong> page. try killing the server and
     waiting a couple of minutes.
    </div>
  }

  Server.start(Server.http,
    {title:"connection handler test", page:page})
```

Caveats: like many functions in Opa, if you call
set_connection_lost_handler before the client has finished
loading the page, your app will hang. To avoid this, always
call it from within an `onready` or another type of event
handler.
