### PR TITLE
Fix version checking for nodejs 0.10.0

### DIFF
--- a/tools/dependencies/launch_helper.js
+++ b/tools/dependencies/launch_helper.js
@@ -10,10 +10,13 @@
 //    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ////////////////////////////////////
 
-var min_node_version = 'v0.6.0';
+var min_node_version = '0.6.0';
 
-if (process.version < min_node_version) {
+if (flattenVersion(process.versions.node) < flattenVersion(min_node_version)) {
     console.error('Your version of node seems to be too old. Please upgrade to a more recent version of node (>= '+min_node_version+')');
     process.exit(1);
 }
 
+function flattenVersion(version) {
+    return parseInt(version.replace(/\./g,''));
+}


### PR DESCRIPTION
On Ubuntu 12.04, using nodejs from the recommended PPA.

``` bash
$ nodejs --version
v0.10.0
$ opa create foo
Your version of node seems to be too old. Please upgrade to a more recent version of node (>= v0.6.0)
```

Patch should be a bit more robust than the older method for future versions.
