### PR TITLE
Fix email

### DIFF
--- a/lib/plugins/mail/bslSmtp.nodejs
+++ b/lib/plugins/mail/bslSmtp.nodejs
@@ -68,21 +68,18 @@ var debug = false
 	      args: ["-t -f "+mfrom_address_only]
 	  });
       } else {
-	  var addr = option2default(via, addr.some)
-	  var port = option2default(port, 25)
-	  var secure = !(secure_type.none);
-	  var user = option2default(user, "");
-	  var pass = option2default(pass, "")
-	  smtpTransport = nodemailer.createTransport("SMTP", {
-	      host: addr,
-	      port: port,
-	      secureConnection: secure,
-	      debug: debug,
-	      auth: {
-		  user:user,
-		  pass:pass
-	      }
-	  });
+	  var options = {
+	      host: option2default(via, addr.some),
+	      port: option2default(port, 25),
+	      secureConnection: !(secure_type.none),
+	      debug: debug};
+	  if (!auth.none) {
+	      options.auth = {
+		  user: option2default(user, ""),
+		  pass: option2default(pass, "")
+	      };
+	  }
+	  smtpTransport = nodemailer.createTransport("SMTP", options);
       }
 
       if (dryrun) {


### PR DESCRIPTION
Here are two bugfixes in email sending from OPA, uncovered while having my students work on an OPA project:
- When using the sendmail transport, `-t` needs to be provided on the command line. nodemail.js used to do that, but removed this recently without updating the documentation ( andris9/Nodemailer@b14bf2af9d442fbfd9321595fca321c9db746dac). An issue has been opened to update the doc.
- When using the SMTP transport, authentication is attempted even when it is not requested because the nodemailer.js option was unconditionally added an `auth` field.
