### PR TITLE
[enhance] facebook: allow the use of a dispatcher

### DIFF
--- a/lib/stdlib/apis/facebook/auth/auth.opa
+++ b/lib/stdlib/apis/facebook/auth/auth.opa
@@ -153,7 +153,25 @@ FbAuth(conf:Facebook.config) = {{
    * an error in case of failure
    */
   get_token_raw(rawdata, redirect_uri) : FbAuth.token_res =
-    match Dialog.oauth_res(rawdata) with
+    get_token(API_libs.get_data(rawdata), redirect_uri)
+
+  /**
+   * Gets an access token directly from the query string provided with the user
+   * redirection after a [user_login_url]. Requesting several times an
+   * access token from the same data will always return the same token with
+   * the same expiration date. If the permission [offline_access] is granted,
+   * the token will not expire.
+   *
+   * @param query Data provided with user redirection.
+   * @param redirect_uri Address where the user will be redirected after
+   * accepting (or not). Domain must match the domain configured for
+   * your application on Facebook.
+   *
+   * @return A [FbAuth.token_res] with either a token or
+   * an error in case of failure
+   */
+  get_token(query, redirect_uri) : FbAuth.token_res =
+    match Dialog.oauth_res(query) with
     | { error=e } -> { error=e }
     | { code=c } -> get_token_from_code(c.code, redirect_uri)
 

--- a/lib/stdlib/apis/facebook/dialog/dialog.opa
+++ b/lib/stdlib/apis/facebook/dialog/dialog.opa
@@ -176,8 +176,7 @@ FbDialog(conf:Facebook.config) = {{
   /**
    * Parser for the GET parameters resulting of a OAuth dialog
    */
-  oauth_res(rawdata) : FbDialog.oauth_res =
-    data = API_libs.get_data(rawdata)
+  oauth_res(data) : FbDialog.oauth_res =
     get_field(name) = API_libs.get_field(data, name)
     if data == [] then
 	{ error = Facebook.data_error }


### PR DESCRIPTION
The Facebook token retriever function requires a raw unparsed query
string that it parses immediately. This prevents users from using a
dispatcher because the query string has been parsed already.

This change allows either a query string or a list of tuples to be used
when handling the answer coming from Facebook redirection.

Example:

``` javascript
    function connect(query) {
        match (FBA.get_token(query, redirect)) { … }
    }
…
    match (url) {
        case {path:["connect"] ...} : connect(url.query)
    }
```
