### PR TITLE
hack to compile with my debian jessie using a recent ocamlgraph package

### DIFF
--- a/compiler/buildinfos/generate_buildinfos.sh
+++ b/compiler/buildinfos/generate_buildinfos.sh
@@ -159,6 +159,10 @@ for repo in $REPOS ; do
     elif ! is_git_root $repo; then
         echo "let ${repo}_git_version = 0"
         echo "let ${repo}_git_sha = \"\""
+# PL fix , seems build expects to find opa_git_version
+        echo "let opa_git_version = 0"
+        echo "let opa_git_sha = \"\""
+
     else
         if [ "$repo" = "$ROOT_REPO" ] ; then
             echo "let opa_git_version = $(in_repo $repo git_opalang_version_cmd)"

--- a/tools/odep.ml
+++ b/tools/odep.ml
@@ -100,7 +100,7 @@ struct
       else
         match String.split_char '/' m.Module.path with
         | _libroot,"" -> None
-        | _libroot,subpath -> Some { Graph.Graphviz.DotAttributes. sg_name = subpath; sg_attributes = [ `Label subpath ] }
+        | _libroot,subpath -> Some { Graph.Graphviz.DotAttributes. sg_name = subpath; sg_attributes = [ `Label subpath ]; sg_parent =  None }
     let default_edge_attributes _t = []
     let edge_attributes _e = []
   end
@@ -135,6 +135,7 @@ struct
           (fun repo -> {
              Graph.Graphviz.DotAttributes.sg_name = repo;
              Graph.Graphviz.DotAttributes.sg_attributes = [ `Label repo ];
+             Graph.Graphviz.DotAttributes.sg_parent = None ;
            })
           l.Lib.repo
     let default_edge_attributes _t = []


### PR DESCRIPTION
- building( make all ) in git cloned did 
  
  [!] Git repo info for opalang not found
  + /usr/bin/ocamlc -c -g -warn-error A -w L -w Z -I compiler/buildinfos -I ocamllib -I tools -I lib -I compiler -I tools/build -o compiler/buildinfos/buildInfos.cmo compiler/buildinfos/buildInfos.ml
  File "compiler/buildinfos/buildInfos.ml", line 20, characters 2-17:
  Error: Unbound value opa_git_version

=> I added opa_git_version additionally to ${repo}_git_version to be able to compile.
- after first fix another build error popped up 

\+ /usr/bin/ocamlc -c -g -thread -warn-error A -w L -w Z -I /usr/lib/ocaml/zip -I /usr/lib/ocaml/ocamlgraph -I /usr/lib/ocaml/ulex -I ocamllib/libbase -I tools -I ocamllib -I lib -I compiler -I tools/build -o tools/odep.cmo tools/odep.ml
File "tools/odep.ml", line 103, characters 35-122:
Error: Some record fields are undefined: sg_parent

After review it come form a ocamlgraph api changes 
[ https://github.com/backtracking/ocamlgraph commit e5aa3733de34fc5da4aa3acb82862b3e88a3062a did add sg_parent field, fix code to compile with that change. ]

=> i added sg_parent = None when needed .

( my first pull request so be kind with this post quality ).
