### PR TITLE
fix invalid printf format

### DIFF
--- a/ocamllib/libbase/date.ml
+++ b/ocamllib/libbase/date.ml
@@ -76,7 +76,7 @@ let date f dt = match f with
 
 let pretty_duration dur =
   if dur < 2. then
-    Printf.sprintf "00:00:0%0.3f" dur
+    Printf.sprintf "00:00:0%.3f" dur
   else if dur < 10. then
     Printf.sprintf "00:00:0%.2f" dur
   else if dur < 60. then


### PR DESCRIPTION
There are some format strings that are "invalid" in the opalang sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of opalang, I think the behavior has not changed between 4.01.0 and 4.02.0. The only kind of invalid format is "%0.3f". This is considered invalid beause it specifies a padding character (with the flag 0), but no minimum field width (no number before the dot) so there will never be padding. Even though the behaviour has not changed, you should take the opportunity to review the code and fix the format. The patch changes it to "%.3f", which keeps the behaviour unchanged, but that might still be wrong.
