### PR TITLE
[fix] Postgres errors on app startup: use alternate DDL statements to avoid

### DIFF
--- a/compiler/opa/pass_PostgresCodeGeneration.ml
+++ b/compiler/opa/pass_PostgresCodeGeneration.ml
@@ -232,7 +232,7 @@ struct
     aux ty
 
   let make_env gamma annotmap schema = {
-    tb_init = ["CREATE LANGUAGE plpgsql"];
+    tb_init = ["CREATE OR REPLACE LANGUAGE plpgsql"];
     ty_init = StringListMap.empty;
     tb_default = StringListMap.empty;
     q_prepared = QueryMap.empty;
@@ -1342,7 +1342,7 @@ struct
     | Q.TypeRecord Q.TyRow (fields , None) ->
         let buffer = Buffer.create 256 in
         let fmt = Format.formatter_of_buffer buffer in
-        Format.fprintf fmt "CREATE TABLE %a("
+        Format.fprintf fmt "CREATE TABLE IF NOT EXISTS %a("
           pp_table_name path;
         let rec aux_field fmt (s, ty) =
           Format.fprintf fmt "%a %a" pp_pgfield s (pp_type_as_pgtype ~path:(List.rev (s::path)) env) ty


### PR DESCRIPTION
I'm getting Postgres error messages each time I start my compiled app:

```
$ ./biking.exe
Http serving on http://tha-tha.local:8080
DbPostgres(biking) An error occurs while processing an initial query:
error: {postgres = {error = [{f1 = 83; f2 = ERROR}, {f1 = 67; f2 = 42710}, {f1 = 77; f2 = language "plpgsql" already exists}, {f1 = 70; f2 = proclang.c}, {f1 = 76; f2 = 356}, {f1 = 82; f2 = create_proc_lang}]}}
query: CREATE LANGUAGE plpgsql

DbPostgres(biking) An error occurs while processing an initial query:
error: {postgres = {error = [{f1 = 83; f2 = ERROR}, {f1 = 67; f2 = 42P07}, {f1 = 77; f2 = relation "_default" already exists}, {f1 = 70; f2 = heap.c}, {f1 = 76; f2 = 1047}, {f1 = 82; f2 = heap_create_with_catalog}]}}
query: CREATE TABLE _default(counter INT8, _id INT8,  PRIMARY KEY(_id))
```
- Attempting to run **CREATE TABLE** each time the app starts will cause an error messages (e.g. `{f1 = 77; f2 = relation "_default" already exists}`)
- Running **CREATE LANGUAGE** on each app startup will similarly cause: `{f1 = 77; f2 = language "plpgsql" already exists}`

Using **CREATE TABLE IF NOT EXISTS** and **CREATE OR REPLACE LANGUAGE** will fix these in Postgres versions 9.1 and greater (released in 2011).
