### PR TITLE
Feature System.execo: exec with options

### DIFF
--- a/lib/plugins/unix/bslSys.nodejs
+++ b/lib/plugins/unix/bslSys.nodejs
@@ -11,6 +11,7 @@ fs.existsSync = fs.existsSync ? fs.existsSync : path.existsSync;
 /** @opaType outcome('a,'b) */
 /** @opaType System.process */
 /** @opaType System.process.out */
+/** @opaType System.exec_options */
 
 /** This returns the raw arguments from the command line,
  *  it's used to seed the Opa version of ServerArgs.
@@ -56,11 +57,19 @@ function exit(code) {
 /** @module process */
 
 /**
- * @register {string, string, continuation(string) -> void}
+ * @register {string, opa[System.exec_options], continuation(string) -> void}
  * @cpsBypass
  */
-function exec_cps(command, input, cont) {
-    var proc = child_process.exec(command,
+function exec_cps(command, options, cont) {
+    var opt = { cwd: options.cwd };
+    if (options.timeout != undefined)
+       opt.timeout = options.timeout;
+    if (options.maxBuffer != undefined)
+       opt.maxBuffer = options.maxBuffer;
+    if (options.killSignal != undefined)
+       opt.killSignal = options.killSignal;
+
+    var proc = child_process.exec(command, opt,
       function (error, stdout, stderr) {
         // We ignore the standard error
         if (error == null) {
@@ -71,7 +80,8 @@ function exec_cps(command, input, cont) {
       }
     );
 
-    proc.stdin.write(input);
+    if (options.input != undefined)
+        proc.stdin.write(options.input);
     proc.stdin.end();
 
     return;
@@ -79,9 +89,9 @@ function exec_cps(command, input, cont) {
 
 // Stub for the typechecker
 /**
- * @register {string, string -> string}
+ * @register {string, System.exec_options -> string}
  */
-function exec(command, input) {
+function exec(command, options) {
    assert(false);
 }
 

--- a/lib/stdlib/system/system.opa
+++ b/lib/stdlib/system/system.opa
@@ -49,6 +49,13 @@ type System.process.out = {
      error : option(string)
 }
 
+type System.exec_options = {
+    input: string
+    cwd: option(string)
+    timeout: int
+    maxBuffer: int
+    killSignal: string
+}
 
 /**
  * Binding with module System
@@ -137,6 +144,10 @@ System = {{
    */
   gmt_launch_date = Date.now_gmt()
 
+  execo = @may_cps(%%bslSys.process.exec%%) : string, System.exec_options -> string
+
+  exec_default_options =  { input = "" cwd = {none} timeout = 0 maxBuffer = 204800 killSignal = "SIGTERM" } : System.exec_options
+
   /**
    * [exec(command, input)]
    * acts like: echo input | command > output
@@ -147,7 +158,7 @@ System = {{
    * In case of error, return the error message instead of the process output.
    * @return raw result
    */
-  exec = @may_cps(%%bslSys.process.exec%%) : string, string -> string
+  exec(command, input) = execo(command, {exec_default_options with ~input })
 
   @private
   async_shell_exec = %%bslSys.process.async_shell_exec%% : string, string, (System.process.out->void) -> System.process


### PR DESCRIPTION
I needed System.exec with a buffer bigger than the default one (200KB)
Added options input, cwd, timeout and killsignal too, as available in Nodejs
