### PR TITLE
Remove special comments from function bodies

### DIFF
--- a/compiler/passes/surfaceAstDependencies.ml
+++ b/compiler/passes/surfaceAstDependencies.ml
@@ -577,7 +577,7 @@ let reorder_expr :
 *)
 let reorder_for_pat_bindings x =
   reorder_expr OpaWalk.Pattern.get_vars x
-(**
+(*
    same as above, with (ident * expr) list
 *)
 let reorder_for_ident_bindings x y =

--- a/compiler/passes/surfaceAstRenaming.ml
+++ b/compiler/passes/surfaceAstRenaming.ml
@@ -528,7 +528,7 @@ let get_tuple_size name =
             | Some n -> if n >= 0 then Some n else None
         )
     | _ -> None
-(** Interface to the stuff on tuples *)
+(* Interface to the stuff on tuples *)
 let add_tuple mk_ident name =
   match get_tuple_size name with
     | None -> `none

--- a/compiler/qmlslicer/qmlSimpleSlicer.ml
+++ b/compiler/qmlslicer/qmlSimpleSlicer.ml
@@ -113,7 +113,7 @@ module WClass = struct
         ~err:false
         ~enable:true
         ()
-    (** when an exposed directive is adding an entry point uselessly TODO *)
+    (* when an exposed directive is adding an entry point uselessly TODO *)
     let useless =
       WarningClass.create
         ~parent:all
@@ -123,7 +123,7 @@ module WClass = struct
         ~err:false
         ~enable:true
         ()
-    (** when a exposed directive is generating first order call back to the client *)
+    (* when a exposed directive is generating first order call back to the client *)
     let misleading =
       WarningClass.create
         ~parent:all


### PR DESCRIPTION
Improper special comments produce a warning which aborts the compilation process in OCaml 4.02.3. For example:

```
File "compiler/qmlslicer/qmlSimpleSlicer.ml", line 116, characters 4-76:
Warning 50: ambiguous documentation comment
File "compiler/qmlslicer/qmlSimpleSlicer.ml", line 126, characters 4-85:
Warning 50: ambiguous documentation comment
File "/tmp/ocamlpp46c604", line 1:
Error: Some fatal warnings were triggered (2 occurrences)
Command exited with code 2.
Compilation unsuccessful after building 1561 targets (1556 cached) in 00:00:35.
```

This PR fixes this.
